### PR TITLE
perf: 画像にpriorityを追加しLCPを改善

### DIFF
--- a/src/app/features/about/components/AboutSection/AboutSection.tsx
+++ b/src/app/features/about/components/AboutSection/AboutSection.tsx
@@ -92,6 +92,7 @@ const AboutSection = () => {
                         width={170}
                         height={170}
                         className={styles["about-profile-img"]}
+                        priority
                       />
                     </motion.div>
                     <div className={styles["about-profile-info"]}>
@@ -245,6 +246,7 @@ const AboutSection = () => {
                                   alt="GitHub"
                                   width={20}
                                   height={20}
+                                  priority
                                 />
                               </div>
                             </div>
@@ -289,6 +291,7 @@ const AboutSection = () => {
                                   alt="X"
                                   width={20}
                                   height={20}
+                                  priority
                                 />
                               </div>
                             </div>
@@ -333,6 +336,7 @@ const AboutSection = () => {
                                   alt="Zenn"
                                   width={20}
                                   height={20}
+                                  priority
                                 />
                               </div>
                             </div>

--- a/src/app/features/skills/components/SkillCard/SkillCard.tsx
+++ b/src/app/features/skills/components/SkillCard/SkillCard.tsx
@@ -81,6 +81,7 @@ const SkillCard = ({
                   className={`${styles["skill-logo"]} ${viewTransitionImage}`}
                   width={156}
                   height={156}
+                  priority
                 />
               </div>
             </div>

--- a/src/app/works/[id]/page.tsx
+++ b/src/app/works/[id]/page.tsx
@@ -49,6 +49,7 @@ const WorkDetail = async ({ params }: { params: Promise<{ id: string }> }) => {
                       width={1920}
                       height={1080}
                       className={`${styles["work__mv-img"]} ${work.viewTransitionImage}`}
+                      priority
                     />
                   </figure>
                 </div>
@@ -516,6 +517,7 @@ const WorkDetail = async ({ params }: { params: Promise<{ id: string }> }) => {
                             width={800}
                             height={450}
                             className={`${styles["work__sidebar-img"]} ${otherWork.viewTransitionImage}`}
+                            priority
                           />
                         </figure>
                         <h3


### PR DESCRIPTION
## Summary
- AboutSection: プロフィール画像、SNSアイコンにpriority追加
- SkillCard: スキルロゴにpriority追加
- WorkDetail: メイン画像、サイドバー画像にpriority追加

## Test plan
- [x] 各ページでLCPが改善されていることを確認
- [x] 画像の表示に問題がないことを確認