### PR TITLE
refactor(about): Aboutページの文章整理とスタイル改善

### DIFF
--- a/src/app/features/about/components/AboutSection/AboutSection.module.css
+++ b/src/app/features/about/components/AboutSection/AboutSection.module.css
@@ -340,8 +340,7 @@
   }
 }
 
-.about-product-link,
-.about-zenn-link {
+.about-product-link {
   position: relative;
   font-size: 1rem;
   font-weight: var(--font-weight-bold);
@@ -374,8 +373,5 @@
 
 .about-product-link {
   color: #ffc400;
-}
-
-.about-zenn-link {
-  color: var(--color-zenn-blue);
+  display: inline-block;
 }

--- a/src/app/features/about/components/AboutSection/AboutSection.tsx
+++ b/src/app/features/about/components/AboutSection/AboutSection.tsx
@@ -415,90 +415,34 @@ const AboutSection = () => {
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
                       <p>
-                        知的好奇心を原動力に、
-                        <em>&quot;調べまくる.ᐟ　試しまくる.ᐟ.ᐟ&quot;</em>
-                        そんな日々を過ごしています。興味を持った技術はコードを書いて挙動を検証し、
+                        知的好奇心を原動力に<em>&quot;調べ、学び、試す&quot;</em>
+                        そんな日々を過ごしています。
+                      </p>
+                      <p>
+                        興味を持った技術はコードを書いて挙動を検証し、トライ&エラーを繰り返しながら理解を深めるようにしています。
+                      </p>
+                      <p>
+                        また、日々学習を続けていく中で
+                        <em>&quot;継続すること&quot;</em>の大切さを改めて実感し、
                         <em>
-                          &quot;トライ&エラー&quot; を繰り返しながら理解を深めるようにしています。
+                          &quot;学ぶ&quot; 行為そのものを &quot;楽しい体験&quot;
+                          に変えられたら継続に繋がるよな。
                         </em>
-                      </p>
-                      <p>
-                        <em>注力</em>
-                        ：「Next.js」「React」「TypeScript」「LLM / Generative AI」「Context
-                        Engineering」「Interaction / Animation」「UI / UX」
-                      </p>
-                    </motion.dd>
-                  </div>
-
-                  <div className={styles["about-content-group"]}>
-                    <motion.dt
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      transition={{
-                        delay: 3.4,
-                        duration: 0.6,
-                        ease: "easeInOut",
-                      }}
-                      className={`${styles["about-list-title"]} ${styles["scroll-driven-animation"]}`}
-                    >
-                      <span className={styles["light-effect"]}>学び、理解すること</span>
-                    </motion.dt>
-                    <motion.dd
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      transition={{
-                        delay: 3.9,
-                        duration: 0.6,
-                        ease: "easeInOut",
-                      }}
-                      className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
-                    >
-                      <p>
-                        私は日々、自己成長を目的としたキャッチアップとアウトプットを続けていく中で、
-                        <em>&quot;継続すること&quot;</em> の大切さを改めて実感し、
-                        <em>
-                          &quot;学ぶ&quot; という行為そのものを &quot;楽しい体験&quot;
-                          に変えられたら、継続に繋がるよな。
-                        </em>{" "}
-                        という思いが芽生えました。
-                      </p>
-                      <p>
-                        この課題解決のために、私は{" "}
+                        と考え、
                         <Link
-                          href="https://outputquest.com"
+                          href="https://github.com/camoneart/outputquest"
                           target="_blank"
                           rel="noopener noreferrer"
                           className={styles["about-product-link"]}
                         >
                           &quot;OUTPUT QUEST 叡智の継承者&quot;
-                        </Link>{" "}
+                        </Link>
                         というWebアプリを開発しました。
                       </p>
                       <p>
-                        コンセプトは{" "}
-                        <em>
-                          &quot;アウトプットを学びの冒険に変える。RPG風学習支援Webアプリ&quot;
-                        </em>{" "}
-                        です。
-                      </p>
-                      <p>
-                        ゲーミフィケーション要素がアウトプットという行為を「
-                        <em>学びの冒険</em>
-                        」という体験に変え、学習の継続をサポートします。ユーザーが学ぶことを楽しみ、理解を深めることに達成感を覚え、
-                        <em>&quot;ユーザーの幸福度に繋がる体験価値&quot;</em>
-                        の提供で貢献したいという想いで開発しました。
-                      </p>
-                      <p>
-                        また、Web開発やAIに関する技術記事を{" "}
-                        <Link
-                          href="https://zenn.dev/camoneart"
-                          className={styles["about-zenn-link"]}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          Zenn
-                        </Link>
-                        にて執筆しています。
+                        <span className={`font-bold ${styles["light-effect"]}`}>現在の注力</span>
+                        ：Next.js / React / TypeScript / Claude Code / Generative AI / Context
+                        Engineering / Interaction / Animation / UI / UX
                       </p>
                     </motion.dd>
                   </div>
@@ -528,13 +472,15 @@ const AboutSection = () => {
                     >
                       <p>音楽から日々のエネルギーを得ています。</p>
                       <p>
-                        音楽は、僕に &quot;現実逃避&quot; ではなく
-                        <em>&quot;現実と向き合う力&quot;</em>
+                        音楽は僕に
+                        <em>&quot;現実逃避&quot; ではなく &quot;現実と向き合う力&quot;</em>
                         を与えてくれます。
                       </p>
                       <p>
-                        <em>好きなミュージシャン</em>：「Vaundy」「King Gnu」「藤井 風」「SUPER
-                        BEAVER」「Saucy Dog」etc...
+                        <span className={`font-bold ${styles["light-effect"]}`}>
+                          好きなミュージシャン
+                        </span>
+                        ：King Gnu / Saucy Dog / Vaundy / 藤井 風 / SUPER BEAVER etc...
                       </p>
                     </motion.dd>
                   </div>
@@ -550,7 +496,7 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-list-title"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <span className={styles["light-effect"]}>映画鑑賞</span>
+                      <span className={styles["light-effect"]}>映像作品</span>
                     </motion.dt>
                     <motion.dd
                       initial={{ opacity: 0 }}
@@ -562,18 +508,20 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <p>映画鑑賞が趣味で、特に洋画を好んでよく観ます。</p>
+                      <p>映画・ドラマ・アニメなど映像作品を観るのが好きです。</p>
                       <p>
-                        映画は私に、
+                        映像作品は私に、
                         <em>
-                          これまで気づかなかった考え方や視点、異なる文化や価値観との出会いをもたらしてくれる大切な存在
-                        </em>{" "}
+                          &quot;新しい考え方&quot; や &quot;視点&quot;、&quot;異なる文化&quot; や
+                          &quot;価値観&quot; との出会いをもたらしてくれる大切な存在
+                        </em>
                         です。
                       </p>
                       <p>
-                        <em>好きな映画</em>
-                        ：「アメイジング・スパイダーマン」「ヴェノム」「ワンダー
-                        君は太陽」「最高の人生の見つけ方」「最強のふたり」「幸せのちから」「ドリームプラン」「プラダを着た悪魔」「マイ・インターン」「42～世界を変えた男～」「ラ・ラ・ランド」「グリーンブック」「フォレスト・ガンプ」「ショーシャンクの空に」「イコライザー」「アメリカン・スナイパー」「素晴らしきかな、人生」「ターミナル」「イエスタデイ」etc...
+                        <span className={`font-bold ${styles["light-effect"]}`}>好きな作品</span>
+                        ：アメイジング・スパイダーマン / マイ・インターン / ワンダー 君は太陽 /
+                        最高の人生の見つけ方 / 最高のふたり / The Rookie / 信長協奏曲 /
+                        王様ランキング / Dr.Stone etc...
                       </p>
                     </motion.dd>
                   </div>
@@ -603,12 +551,11 @@ const AboutSection = () => {
                     >
                       <p>ジャンルを問わず気になった書籍を読むのが好きです。</p>
                       <p>
-                        読書では、
+                        読書では
                         <em>新たな知識を得たり、著者の考え方や価値観を学ぶことができます。</em>
                       </p>
                       <p>
-                        私にとっての書籍は、
-                        <em>&quot;先人の知恵を学ぶことができるアイテム&quot;</em> といった存在です。
+                        私にとっての書籍は<em>&quot;先人の知恵を学べるアイテム&quot;</em>です。
                       </p>
                     </motion.dd>
                     <motion.dd
@@ -622,12 +569,11 @@ const AboutSection = () => {
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
                       <p>
-                        お気に入りの書籍は、
-                        <em>
-                          ｢クリエイティブの授業 STEAL LIKE AN ARTIST
-                          &quot;君がつくるべきもの&quot;をつくれるようになるために｣
-                        </em>{" "}
-                        です。
+                        <span className={`font-bold ${styles["light-effect"]}`}>
+                          お気に入りの書籍
+                        </span>
+                        ：クリエイティブの授業 STEAL LIKE AN ARTIST "君がつくるべきもの"
+                        をつくれるようになるために
                       </p>
                     </motion.dd>
                   </div>
@@ -689,14 +635,11 @@ const AboutSection = () => {
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
                       <p>
-                        <em>LLM</em>, <em>Generative AI</em>, <em>AI Agents</em>
-                        に注力し、AIを日常的に利用しています。
-                      </p>
-                      <p>
+                        LLM / Generative AI / AI Agentに注力し、AIを日常的に活用しています。
                         AIを活用して生産性を上げることで、
                         <em>
-                          今まで以上にクリエイティブと向き合う時間に集中できるようになれる
-                        </em>{" "}
+                          人は今まで以上にクリエイティブと向き合う時間に集中できるようになれる
+                        </em>
                         と私は考えています。
                       </p>
                     </motion.dd>
@@ -758,10 +701,7 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <p>
-                        <em>ポジティブ</em> / <em>知的好奇心</em> / <em>探究心</em> /{" "}
-                        <em>自走力</em> / <em>継続力</em>
-                      </p>
+                      <p>ポジティブ / 知的好奇心 / 探究心 / 自走力 / 継続力</p>
                     </motion.dd>
                   </div>
                   <div className={styles["about-content-group"]}>
@@ -787,9 +727,7 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <p>
-                        <em>ダイエット（過去-40kgの減量に成功）</em>
-                      </p>
+                      <p>ダイエット（過去-40kgの減量に成功）</p>
                     </motion.dd>
                   </div>
                   <div className={styles["about-content-group"]}>
@@ -815,9 +753,7 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <p>
-                        <em>怒ること</em> / <em>諦めること</em>
-                      </p>
+                      <p>怒ること / 諦めること</p>
                     </motion.dd>
                   </div>
                 </dl>
@@ -843,7 +779,7 @@ const AboutSection = () => {
                   transition={{ delay: 2.1, duration: 0.6, ease: "easeInOut" }}
                   className={`font-russo ${styles["about-title-lv2"]} ${styles["scroll-driven-animation"]}`}
                 >
-                  Vision
+                  Values
                 </motion.h2>
                 <motion.div
                   initial={{ width: 0 }}
@@ -865,7 +801,7 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-list-title"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <span className={styles["light-effect"]}>「来年のための今年」</span>
+                      <span className={styles["light-effect"]}>日々アップデートする</span>
                     </motion.dt>
                     <motion.dd
                       initial={{ opacity: 0 }}
@@ -877,7 +813,6 @@ const AboutSection = () => {
                       }}
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
-                      <p>「来年のために今年はなにができるだろう？」と常に考えています。</p>
                       <p>
                         <em>とにかく自分をアップデートし続けたいです。</em>
                         やりたいこと、際限ないです。
@@ -911,11 +846,9 @@ const AboutSection = () => {
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
                       <p>
-                        Webサービスを通じてお客様に価値あるプロダクトを高速で届け、
-                        <em>&quot;喜びや幸せに繋がる価値&quot;</em>
-                        の提供で貢献し、
-                        <em>社会にポジティブな変化を生み出す活動を続けていきたいです。</em>
-                        そのために知的好奇心を原動力にアンラーンして学び続け、クリエイティブに没頭したいです！
+                        Webサービスを通じてユーザーに<em>&quot;喜びや幸せに繋がる価値&quot;</em>
+                        を届け、<em>社会にポジティブな変化を生み出す活動を続けていきたいです。</em>
+                        そのために、知的好奇心を原動力に学び続け、これからもクリエイティブに没頭していきたいです。
                       </p>
                     </motion.dd>
                   </div>
@@ -944,12 +877,11 @@ const AboutSection = () => {
                       className={`${styles["about-description"]} ${styles["scroll-driven-animation"]}`}
                     >
                       <p>
-                        <em>&quot;変化を恐れず、現状に満足するな&quot;</em>
-                        をモットーとしています。
+                        <em>&quot;変化を恐れず、現状に満足するな&quot;</em>をモットーとしています。
                       </p>
                       <p>
-                        <em>&quot;楽な道のりよりも、険しい道の歩き方&quot;</em> を知りたいし、
-                        地に足をつけ、学びを大切とし、謙虚さを忘れず、挑戦を続けることで、
+                        <em>&quot;楽な道のりよりも、険しい道の歩き方&quot;</em>
+                        を知りたいし、地に足をつけ、学びを大切とし、謙虚さを忘れず、挑戦を続けることで、
                         <em>&quot;見たことも無い、想像もできなかった景色と出会える&quot;</em>
                         と私は信じています。
                       </p>


### PR DESCRIPTION
## Summary
- 「学び、理解すること」セクションを「Web開発」に統合し、冗長な記述を削減
- 「映画鑑賞」→「映像作品」にセクション名変更（映画・ドラマ・アニメを包含）
- 「Vision」→「Values」にセクション名変更（内容に即したタイトルに）
- 各セクションの文章を簡潔に整理
- `em`タグの過剰使用を削減し、`span`+`light-effect`クラスに統一
- OUTPUT QUESTリンクのホバースタイル修正（`display: inline-block`追加）
- 不要な`about-zenn-link`スタイルを削除

## Changes
- `AboutSection.tsx`: 125行削除、53行追加（-72行）
- `AboutSection.module.css`: スタイル整理