### PR TITLE
fix: 不要なReact importを削除

### DIFF
--- a/src/app/features/contact/components/AdminEmailTemplate/AdminEmailTemplate.tsx
+++ b/src/app/features/contact/components/AdminEmailTemplate/AdminEmailTemplate.tsx
@@ -1,15 +1,10 @@
-import * as React from "react";
-
-interface AdminEmailTemplate {
+interface AdminEmailTemplateProps {
   username: string;
   email: string;
   content: string;
 }
 
-export const AdminEmailTemplate: React.FC<Readonly<AdminEmailTemplate>> = ({
-  username,
-  content,
-}) => (
+export const AdminEmailTemplate = ({ username, content }: AdminEmailTemplateProps) => (
   <div>
     <h3>{username}様から、お問い合わせが届きました。</h3>
     <h3>お問い合わせ内容は以下の通りです。</h3>

--- a/src/app/features/contact/components/AutoReplyEmailTemplate/AutoReplyEmailTemplate.tsx
+++ b/src/app/features/contact/components/AutoReplyEmailTemplate/AutoReplyEmailTemplate.tsx
@@ -3,10 +3,7 @@ interface AutoReplyEmailTemplateProps {
   content: string;
 }
 
-export const AutoReplyEmailTemplate: React.FC<AutoReplyEmailTemplateProps> = ({
-  username,
-  content,
-}) => (
+export const AutoReplyEmailTemplate = ({ username, content }: AutoReplyEmailTemplateProps) => (
   <div>
     <h3>{username} 様</h3>
     <h3>お問い合わせありがとうございます。</h3>


### PR DESCRIPTION
## Summary
- AdminEmailTemplate.tsx: 不要な `import * as React from "react"` を削除
- AutoReplyEmailTemplate.tsx: 欠落していた import を追加せず、React.FC を使わないモダンな書き方に変更
- 両ファイルで `React.FC` を使わない現代的なTypeScript記法に統一