### PR TITLE
fix: Contactページの色をピンク系に統一

### DIFF
--- a/src/app/features/contact/components/ContactForm/ContactForm.tsx
+++ b/src/app/features/contact/components/ContactForm/ContactForm.tsx
@@ -24,14 +24,14 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 const notify = () =>
   toast.success("お問い合わせありがとうございます！", {
     style: {
-      border: "2px solid #bd4d0d",
+      border: "2px solid #ff6b8a",
       padding: "16px",
       color: "#000",
       fontSize: "14px",
       fontWeight: "bold",
     },
     iconTheme: {
-      primary: "#bd4d0d",
+      primary: "#ff6b8a",
       secondary: "#FFFAEE",
     },
   });
@@ -177,7 +177,7 @@ const ContactForm = () => {
             />
             <div className={styles["contact-form-send-btn-container"]}>
               {form.formState.isSubmitting ? (
-                <ProgressBar height="100" width="100" barColor="#ca510c99" borderColor="#bd4d0d" />
+                <ProgressBar height="100" width="100" barColor="#f64d5a99" borderColor="#e74f64" />
               ) : (
                 <button
                   type="submit"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,7 +81,6 @@
     --color-primary-gray: #262626;
     --color-primary-pink: #ff6b8a;
     --color-primary-light-pink: #ffa8ba;
-    --color-secondary-pink: #e63946;
     --stairs-column-color: #813049;
     --text-gradient-primary: linear-gradient(108deg, #ff6b8a, #e63946 70%, #ff4a5a);
     --label-bg-color: rgb(246 77 90 / 25%);
@@ -177,7 +176,7 @@
   }
 
   :focus-visible {
-    outline: 1px solid var(--color-secondary-pink);
+    outline: 1px solid var(--color-primary-pink);
   }
 
   ::selection {


### PR DESCRIPTION
## Summary
- ContactForm の toast 通知色をオレンジ系からピンク系 (`#ff6b8a`) に変更
- ProgressBar の色もピンク系に統一
- 未使用の `--color-secondary-pink` CSS変数を削除
- `:focus-visible` のアウトライン色を `--color-primary-pink` に変更