### PR TITLE
fix: ContactFormのlabelクリックで入力欄にfocusが当たるよう修正

### DIFF
--- a/src/app/features/contact/components/ContactForm/ContactForm.tsx
+++ b/src/app/features/contact/components/ContactForm/ContactForm.tsx
@@ -78,23 +78,23 @@ const ContactForm = () => {
                     <FormLabel>
                       Username<span className={styles["required"]}>*</span>
                     </FormLabel>
-                    <FormControl>
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <FormControl>
                             <Input
                               placeholder="First & Last Name"
                               {...field}
                               className="px-4 py-7"
                               disabled={form.formState.isSubmitting}
                             />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>お名前を入力してください</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </FormControl>
+                          </FormControl>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>お名前を入力してください</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -107,23 +107,23 @@ const ContactForm = () => {
                     <FormLabel>
                       Email<span className={styles["required"]}>*</span>
                     </FormLabel>
-                    <FormControl>
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <FormControl>
                             <Input
                               placeholder="Your email address"
                               {...field}
                               className="px-4 py-7"
                               disabled={form.formState.isSubmitting}
                             />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>メールアドレスを入力してください</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </FormControl>
+                          </FormControl>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>メールアドレスを入力してください</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -137,18 +137,18 @@ const ContactForm = () => {
                   <FormLabel>
                     Subject<span className={styles["required"]}>*</span>
                   </FormLabel>
-                  <FormControl>
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <FormControl>
                           <Input placeholder="Subject" {...field} className="px-4 py-7" disabled={form.formState.isSubmitting} />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>件名を入力してください</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </FormControl>
+                        </FormControl>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>件名を入力してください</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                   <FormMessage />
                 </FormItem>
               )}
@@ -161,18 +161,18 @@ const ContactForm = () => {
                   <FormLabel>
                     Message<span className={styles["required"]}>*</span>
                   </FormLabel>
-                  <FormControl>
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <FormControl>
                           <Textarea placeholder="Your message here..." {...field} disabled={form.formState.isSubmitting} />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>お問い合わせ内容を入力してください</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </FormControl>
+                        </FormControl>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>お問い合わせ内容を入力してください</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
## Summary
- labelをクリックすると対応する入力欄にfocusが当たるよう修正
- アクセシビリティ・ユーザビリティの向上

## 原因
`FormControl`（Slot）が`id`をInputに渡す際、間に`TooltipProvider`があったため`id`が伝わっていなかった。

## 修正内容
TooltipをFormControlの外に移動し、FormControlがInputを直接ラップするよう変更。

```tsx
// Before（❌）
<FormControl>
  <TooltipProvider>
    <Tooltip>
      <TooltipTrigger asChild>
        <Input />
      </TooltipTrigger>
    </Tooltip>
  </TooltipProvider>
</FormControl>

// After（✅）
<TooltipProvider>
  <Tooltip>
    <TooltipTrigger asChild>
      <FormControl>
        <Input />
      </FormControl>
    </TooltipTrigger>
  </Tooltip>
</TooltipProvider>
```

## 対象フィールド
- Username
- Email
- Subject
- Message