### PR TITLE
CLAUDE.mdをベストプラクティスに沿ってブラッシュアップ

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,12 @@
 
 プロジェクト概要・使用技術・ディレクトリ構造は @README.md を参照。
 
+## 技術スタック
+
+- Next.js 16（App Router + Turbopack）
+- React 19
+- TypeScript 5.9
+
 ## 開発コマンド
 
 パッケージマネージャー: **pnpm** を使用（npm/yarn禁止）
@@ -10,38 +16,34 @@
 - `pnpm build` - 本番ビルド
 - `pnpm lint:fix` - Lint + フォーマット
 
+## 環境変数
+
+- `RESEND_API_KEY` - Resend APIキー（必須）
+- `RESEND_FROM_EMAIL` - メール送信元アドレス（デフォルト値あり）
+
 ## コーディング規約
 
 ### TypeScript
+
 - `any`は禁止、型を明示する
 - 新規コンポーネントは関数宣言で記述
 
 ### スタイリング
+
 - CSS Modules（`.module.css`）+ Tailwind CSSを併用
 - コンポーネント固有のスタイルは`.module.css`に記述
 - BEM風のクラス命名（例：`about-content-group`）
 
 ### アニメーション
+
 - 新規アニメーションはMotionを優先使用
 - GSAPは既存コードとの一貫性が必要な場合のみ
 - アニメーションのdelayは既存パターンに合わせる
 
 ### UIコンポーネント
+
 - `src/components/ui/`のshadcn/uiは変更禁止
 - 新規UIコンポーネントは`src/app/components/`に配置
-
-## アーキテクチャ
-
-```
-src/app/
-├── features/       # 機能別（about, contact, skills, works）
-│   └── {機能名}/
-│       ├── components/
-│       ├── hooks/
-│       └── data/
-├── components/     # 共通（3D, Animation, layouts等）
-└── api/            # APIルート
-```
 
 ## 重要な注意事項
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdをClaude Code公式ドキュメントのベストプラクティスに沿って改善
- 英語から日本語に変更（プロジェクトの言語に統一）
- `@README.md`参照でバージョン情報等の重複を排除
- コーディング規約をカテゴリ別に分割（TypeScript/スタイリング/アニメーション/UIコンポーネント）
- 87行→52行にコンパクト化

## 主な変更点
- **言語**: 英語 → 日本語
- **インポート活用**: `@README.md`を参照することで詳細情報の重複を排除
- **具体性向上**: 「TypeScriptを使用」→「`any`は禁止、型を明示する」など具体的に
- **構造改善**: 箇条書き + 説明的な見出しでスキャンしやすく