### PR TITLE
docs(readme): sync directory structure with actual repo state

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,13 @@ portfolio/
 │   │   └── ui/                     # shadcn/ui コンポーネント
 │   ├── lib/                        # ライブラリ・ユーティリティ
 │   └── utils/                      # ユーティリティ関数
-├── .cursorrules                    # Cursor Rules
+├── .claude/                        # Claude Code 設定（CLAUDE.md + settings.local.json）
 ├── .depcheckrc.json                # 依存関係チェックツール depcheckの設定ファイル
-├── .env                            # 環境変数の設定ファイル
+├── .docs/                          # プロジェクトドキュメント（conventions / plans / security / templates）
 ├── .eslintrc.json                  # ESLint設定ファイル
+├── .github/                        # GitHub設定（dependabot.yml + workflows/ci.yml）
 ├── .gitignore                      # GitHubの差分に含まないものを格納
+├── .mcp.json                       # MCP (Model Context Protocol) サーバー設定
 ├── .npmrc                          # pnpmの設定ファイル
 ├── .prettierrc.json                # Prettierの設定ファイル
 ├── components.json                 # shadcn/ui設定ファイル


### PR DESCRIPTION
## Summary

`README.md` の **ディレクトリ構造** セクションを実態と同期。 PR #43 (脆弱性対応 + `.github/` 追加) 以降に発生したdocumentation driftを解消。

## Changes (-2 / +4 = +2行)

### 削除 (実在しないが記載されていた)

| 項目 | 理由 |
|---|---|
| `.cursorrules` | 過去のCursor利用残骸、 リポに実在せず |
| `.env` | 実在せず (Vercel側env varが本番運用) |

### 追加 (実在するが未記載)

| 項目 | 内容 |
|---|---|
| `.claude/` | Claude Code 設定 (CLAUDE.md + settings.local.json) |
| `.docs/` | プロジェクトドキュメント (conventions / plans / security / templates) |
| `.github/` | GitHub設定 (dependabot.yml + workflows/ci.yml) ※PR #43で追加 |
| `.mcp.json` | MCP (Model Context Protocol) サーバー設定 |

### 維持 (記載と実態が一致)

- `.depcheckrc.json` / `.eslintrc.json` / `.gitignore` / `.npmrc` / `.prettierrc.json`
- `src/` 配下全構造 (components/, features/, app routing)
- `public/` 配下全構造 (audio/, images/)
- ルート設定ファイル群 (package.json, tsconfig.json, next.config.mjs等)

## Background

`audit-status.md` 記載の maintenance backlog (期日 2026-05-31) にdocumentation drift解消は記載なかったが、 `/logging-implementation` skill実行中の検証で発覚。 後日対応より「気づいた時に修正」 が妥当判断。

## 関連PR

- **PR #52** (`chore/post-merge-cleanup`): README versions section更新 (L133-151) + plan archive
- **本PR** (`chore/sync-readme-directory-structure`): README directory section更新 (L226-241)

→ 編集セクションが90行差で **conflict予測なし**。 mergeの順序関係なくauto-merge可能 (検証は実際のmerge時)。

## Test plan

- [ ] CI (audit-only) pass
- [ ] GitHub UI で README ディレクトリ構造 section の描画確認 (アルファベット順 + indent揃い)
- [ ] PR #52 とのmerge時 conflict有無確認

## Out of scope (将来backlog候補)

push時に検出された **GitHub Large File Warning** (4ファイル × ~75MB):
- 既存git history由来 (本PR起因ではない)
- Git LFS移行検討、 もしくは過去commit内大型assets削減
- 影響: clone/push時のbloat化リスク
- 期日: 検討中、 audit-status.md に追記候補