### PR TITLE
chore(gitignore): exclude .claude/handoff-state.md from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ next-env.d.ts
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/handoff-state.md


### PR DESCRIPTION
## 概要

個人のセッション状態ファイル `.claude/handoff-state.md` を git 追跡から除外する。既存の `chore/exclude-docs-from-tracking` (PR #54, .docs/ 除外) と同じ運用パターン。

## 変更

- `.gitignore` に `.claude/handoff-state.md` を1行追加