### PR TITLE
ci: add least-privilege permissions to CI workflow (CodeQL fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -46,4 +49,3 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
-      


### PR DESCRIPTION
## 概要

CodeQL が検出した「Workflow does not contain permissions」(Medium x3) を解消する。

## 背景

PR #64 で CI に追加した `ci.yml` の audit / lint / typecheck の各 job に明示的な `permissions` が無く、GITHUB_TOKEN にデフォルトの過剰な権限が付与されていた。CodeQL の Actions セキュリティルール (最小権限の原則) に反するため、CodeQL 初回スキャンで 3 件検出された。

これは今回 CodeQL を導入した価値そのもの (導入初日に自分の CI の穴を検出)。

## 変更

`ci.yml` の workflow レベルに `permissions: contents: read` を追加。

- 3 job 全てに継承され、GITHUB_TOKEN を読み取り専用に制限
- audit / lint / typecheck はコードを読んで検査するだけなので `contents: read` で必要十分
- ついでに末尾の余分な空白行も除去

## 期待結果

Code scanning alerts (Workflow does not contain permissions x3) が解消され、3 Open -> 0 になる。
