### PR TITLE
chore: rebrand site identity to kaishu｜AI Engineer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # ポートフォリオサイト
 
-aoyamaのポートフォリオ。Motion/GSAP/R3Fで動きと3Dを活かした体験重視サイト。
+kaishuのポートフォリオ。Motion/GSAP/R3Fで動きと3Dを活かした体験重視サイト。
 スコープ外: CMS機能、ブログ、外部API連携（Resend除く）
 
 ## Stack

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# aoyama｜Web Engineer
+# kaishu｜AI Engineer
 
 https://github.com/user-attachments/assets/61740ac9-1dd2-4931-9fc5-9a23454b0a4f
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio-site",
   "version": "0.1.0",
   "private": true,
-  "author": "aoyama",
+  "author": "kaishu",
   "description": "ポートフォリオサイト",
   "homepage": "https://aoyama.dev",
   "repository": {

--- a/src/app/components/layouts/Footer/Footer.tsx
+++ b/src/app/components/layouts/Footer/Footer.tsx
@@ -8,7 +8,7 @@ export default function Footer() {
       <div className={`p-5 grid place-items-center ${styles["footer__container"]}`}>
         <p className={`z-20 ${styles["footer__text"]}`}>
           <small className={`text-xs font-bold ${styles["footer__copyright"]}`}>
-            <span className={`${styles["text-gradient"]}`}>&copy; aoyama</span>
+            <span className={`${styles["text-gradient"]}`}>&copy; kaishu</span>
           </small>
         </p>
       </div>

--- a/src/app/components/layouts/Header/Header.tsx
+++ b/src/app/components/layouts/Header/Header.tsx
@@ -51,8 +51,8 @@ export default function Header() {
             className={`${styles["header__title-link"]}`}
             onClick={() => isOpen && toggleMenu()}
           >
-            <span className={`${styles["text-gradient"]} ${styles["rotate-text01"]}`}>aoyama</span>
-            <span className={`${styles["text-gradient"]} ${styles["rotate-text02"]}`}>aoyama</span>
+            <span className={`${styles["text-gradient"]} ${styles["rotate-text01"]}`}>kaishu</span>
+            <span className={`${styles["text-gradient"]} ${styles["rotate-text02"]}`}>kaiju</span>
           </Link>
         </div>
         <div className={styles["header__items"]}>

--- a/src/app/components/layouts/Hero/Hero.tsx
+++ b/src/app/components/layouts/Hero/Hero.tsx
@@ -4,8 +4,8 @@ import { memo, useEffect, useState } from "react";
 import styles from "./Hero.module.css";
 import { motion } from "motion/react";
 
-const HERO_TITLE = "aoyama";
-const HERO_SUBTITLE = "Web Engineer";
+const HERO_TITLE = "kaishu";
+const HERO_SUBTITLE = "AI Engineer";
 
 // アニメーションのdelay時間を定数として管理
 const ANIMATION_DELAY = {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,7 +4,7 @@ import * as Contact from "@/app/features/contact/components";
 
 export const metadata: Metadata = {
   title: "Contact",
-  description: "このページは、aoyama｜Web Engineerのお問い合わせページになります。",
+  description: "このページは、kaishu｜AI Engineerのお問い合わせページになります。",
 };
 
 const ContactPage = () => {

--- a/src/app/features/contact/components/AutoReplyEmailTemplate/AutoReplyEmailTemplate.tsx
+++ b/src/app/features/contact/components/AutoReplyEmailTemplate/AutoReplyEmailTemplate.tsx
@@ -10,7 +10,7 @@ export const AutoReplyEmailTemplate = ({ username, content }: AutoReplyEmailTemp
     <h3>{username} 様</h3>
     <h3>お問い合わせありがとうございます。</h3>
 
-    <p>この度は「aoyama｜Web Engineer」からお問い合わせいただき、誠にありがとうございます。</p>
+    <p>この度は「kaishu｜AI Engineer」からお問い合わせいただき、誠にありがとうございます。</p>
 
     <div>
       <p>いただいたお問い合わせ内容は以下になります。</p>

--- a/src/app/features/works/data/works.ts
+++ b/src/app/features/works/data/works.ts
@@ -64,7 +64,7 @@ export const worksData: WorksData[] = [
   {
     id: 1,
     image: "/images/works/work01.jpg",
-    workTitle: "aoyama｜Web Engineer",
+    workTitle: "kaishu｜AI Engineer",
     cardDesc:
       "私のポートフォリオサイトになります。サイトデザインを自ら考え、コーディングまで行いました。",
     description:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,8 +17,8 @@ const russoOne = Russo_One({
 
 export const metadata: Metadata = {
   title: {
-    default: "aoyama｜Web Engineer",
-    template: "%s｜aoyama",
+    default: "kaishu｜AI Engineer",
+    template: "%s｜kaishu",
   },
   description:
     "Kaishu Aoyamaのポートフォリオサイトです。モノづくりを通して、ワクワクしたり心踊るような体験を提供したいです。",


### PR DESCRIPTION
## What

サイトのアイデンティティ表記を全面刷新した。

- **肩書き**: `Web Engineer` → `AI Engineer`
- **表示名**: `aoyama` → `kaishu`（ヘッダーロゴはホバーで `kaishu` → `kaiju` に半回転）
- **内部メタ**: `package.json` の `author`、プロジェクト `.claude/CLAUDE.md` の説明文

## Why

専門性の打ち出しを Web 開発から AI エンジニアリングへ転換するブランディング変更。サイト表示・メタデータ・自動返信メール・作品データ・ドキュメントの全箇所で一貫させ、表記の不整合を残さない。

## 変更箇所（10ファイル / +13 -13）

| 種別 | ファイル | 変更 |
|------|---------|------|
| ファーストビュー | `Hero.tsx` | title `aoyama`→`kaishu` / subtitle `Web Engineer`→`AI Engineer` |
| ヘッダーロゴ | `Header.tsx` | 表 `kaishu` / 裏（ホバー）`kaiju` |
| フッター | `Footer.tsx` | `© aoyama`→`© kaishu` |
| メタデータ | `layout.tsx` | `title.default` と `template` を `%s｜kaishu` |
| メタデータ | `contact/page.tsx` | description |
| 自動返信メール | `AutoReplyEmailTemplate.tsx` | 本文 |
| 作品データ | `works.ts` | `workTitle`（/works・works詳細・Other Works に反映） |
| ドキュメント | `README.md` | 見出し |
| 内部メタ | `package.json` | `author` |
| 内部メタ | `.claude/CLAUDE.md` | 説明文 |

## 意図的に保持（変更しない）

- フルネーム **Kaishu Aoyama**（姓は本名。機械置換だと "Kaishu Kaishu" に壊れる）
- ドメイン `aoyamadev.com` / `aoyama.dev`、メール `kaishuaoyama@gmail.com`（実在リソース）

## 検証

- `grep "Web Engineer"` → **0件**、残存 `aoyama` は保持対象（フルネーム 6 / ドメイン 3 / メール 1）のみ
- `pnpm install --frozen-lockfile`（lockfile 不変）+ `tsc --noEmit` → **exit 0**