### PR TITLE
style: tighten header title-link padding-block and add letter-spacing

### DIFF
--- a/src/app/components/layouts/Header/Header.module.css
+++ b/src/app/components/layouts/Header/Header.module.css
@@ -19,6 +19,7 @@
   padding-block: 6px;
   padding-inline: 14px;
   letter-spacing: 0.05em;
+  text-align: center;
 
   @media (768px <= width) {
     overflow: hidden;

--- a/src/app/components/layouts/Header/Header.module.css
+++ b/src/app/components/layouts/Header/Header.module.css
@@ -16,8 +16,9 @@
 
 .header__title-link {
   display: block grid;
-  padding-block: 6px 8px;
+  padding-block: 6px;
   padding-inline: 14px;
+  letter-spacing: 0.05em;
 
   @media (768px <= width) {
     overflow: hidden;


### PR DESCRIPTION
## What

ヘッダーロゴ（`header__title-link`）のスペーシング・配置を微調整:

- `padding-block: 6px 8px` → `6px`（上下パディングを対称化）
- `letter-spacing: 0.05em` を追加
- `text-align: center` を追加（中央揃え）

## Why

ロゴ（`kaishu` / ホバーで `kaiju`）の見た目を整える。上下パディングの非対称を解消し、字間を広げ、中央揃えで配置を安定させる。

## 変更

- `src/app/components/layouts/Header/Header.module.css`（2 コミット）

## 検証

- 見た目のみの変更でロジック・型に影響なし
- Vercel Preview で本番相当の表示を確認可能