### PR TITLE
feat: reshape 3D cube cluster into heart-leaning pulsing cube cloud

### DIFF
--- a/src/app/components/3D/Cube/Cube.tsx
+++ b/src/app/components/3D/Cube/Cube.tsx
@@ -25,12 +25,15 @@ const Cube = ({ position, float, scatter }: CubeProps) => {
   const velocityRef = useRef(new THREE.Vector3());
   const initialPosition = useMemo(() => position.clone(), [position]);
   const currentHoverValue = useRef(0); // 現在のホバー値を追跡
+  // 中心（原点）からの距離。波紋アニメーションの位相に使う
+  const centerDist = useMemo(() => initialPosition.length(), [initialPosition]);
 
   const material = useMemo(() => {
     return new THREE.ShaderMaterial({
       uniforms: {
         time: { value: 0 },
         hover: { value: 0.0 },
+        uDist: { value: centerDist },
         color1: { value: new THREE.Color(0xff5a78) },
         color2: { value: new THREE.Color(0xff8fa8) },
         color3: { value: new THREE.Color(0xffc8d8) },
@@ -56,6 +59,7 @@ const Cube = ({ position, float, scatter }: CubeProps) => {
       fragmentShader: `
         uniform float time;
         uniform float hover;
+        uniform float uDist;
         uniform vec3 color1;
         uniform vec3 color2;
         uniform vec3 color3;
@@ -69,11 +73,19 @@ const Cube = ({ position, float, scatter }: CubeProps) => {
 
           float fresnel = 0.1 + pow(1.0 + dot(viewDir, normal), 2.0);
 
+          // 立体グラデーション（上が濃く下が淡い陰影。立体感を保つ）
           float gradientFactor = (-vPosition.y + 0.5);
           vec3 gradient = mix(color1, color2, gradientFactor);
           gradient = mix(gradient, color3, gradientFactor * 0.5);
 
-          vec3 color = mix(gradient, gradient * 1.2, fresnel + hover * 0.3);
+          // 中心から外へ広がる波紋。速度はうねり（拡大縮小）と同じ time*0.55 に揃える
+          float wave = sin(uDist * 0.9 - time * 0.55);
+          float pulse = wave * 0.5 + 0.5;
+          vec3 rippled = mix(gradient, color3, pulse * 0.45); // 波の山で淡ピンク白へ
+          float glow = smoothstep(0.6, 1.0, pulse);
+
+          vec3 color = mix(rippled, rippled * 1.3, fresnel + hover * 0.3);
+          color += color3 * glow * 0.25; // 波の山で発光
 
           gl_FragColor = vec4(color, 0.85 + hover * 0.15);
         }
@@ -81,7 +93,7 @@ const Cube = ({ position, float, scatter }: CubeProps) => {
       transparent: true,
       side: THREE.DoubleSide,
     });
-  }, []);
+  }, [centerDist]);
 
   useFrame(({ clock }) => {
     if (!meshRef.current) return;
@@ -93,9 +105,6 @@ const Cube = ({ position, float, scatter }: CubeProps) => {
     const hoverSpeed = 0.1; // キューブが膨らむ速度。この値を小さくすると遅く、大きくすると速くなります
     currentHoverValue.current += (hoverRef.current - currentHoverValue.current) * hoverSpeed;
     material.uniforms.hover.value = currentHoverValue.current;
-
-    const floatOffset = Math.sin(time * float.speed + float.offset) * float.amplitude;
-    const floatPosition = initialPosition.clone().add(new THREE.Vector3(0, floatOffset, 0));
 
     meshRef.current.quaternion.setFromAxisAngle(
       float.rotationAxis,
@@ -127,7 +136,15 @@ const Cube = ({ position, float, scatter }: CubeProps) => {
         velocityRef.current.multiplyScalar(-0.5);
       }
     } else {
-      meshRef.current.position.lerp(floatPosition, 0.01);
+      // ノイズ（波の合成）で中心から外へ脈動・うねる（蠢く立方体クラウド）
+      const ip = initialPosition;
+      const wave =
+        Math.sin(ip.x * 0.4 + time * 0.5) +
+        Math.sin(ip.y * 0.45 + time * 0.65) +
+        Math.sin(ip.z * 0.4 + time * 0.55);
+      const radial = ip.clone().normalize();
+      const target = ip.clone().addScaledVector(radial, wave * 0.7);
+      meshRef.current.position.lerp(target, 0.08);
       velocityRef.current.multiplyScalar(0.95);
     }
   });

--- a/src/app/components/3D/Cube/Scene.tsx
+++ b/src/app/components/3D/Cube/Scene.tsx
@@ -17,7 +17,7 @@ const Scene: React.FC = () => {
     (pointer: THREE.Vector2) => {
       camera.position.x += (pointer.x * 0.5 - camera.position.x) * 0.015;
       camera.position.y += (-pointer.y * 0.5 - camera.position.y) * 0.015;
-      camera.lookAt(0, 0, 0); // キューブの位置
+      camera.lookAt(0, 0, 0); // クラウドの中心
     },
     [camera]
   );
@@ -25,8 +25,8 @@ const Scene: React.FC = () => {
   // グループの回転更新を最適化
   const updateGroupRotation = useCallback(() => {
     if (groupRef.current) {
-      groupRef.current.rotation.x += 0.001;
-      groupRef.current.rotation.y += -0.001;
+      groupRef.current.rotation.x += 0.0005;
+      groupRef.current.rotation.y += -0.0005;
     }
   }, []);
 
@@ -42,7 +42,7 @@ const Scene: React.FC = () => {
       <directionalLight position={[5, 5, 5]} castShadow intensity={1} />
       <pointLight position={[-3, 2, 3]} color={0xff69b4} intensity={1} distance={10} />
       <pointLight position={[3, -2, -3]} color={0x00ffff} intensity={1} distance={10} />
-      <group ref={groupRef} position={[0, 0, 0]} rotation={[Math.PI / 4, Math.PI / 4, 0]}>
+      <group ref={groupRef} position={[0, 0, -15]} rotation={[Math.PI / 4, Math.PI / 4, 0]}>
         {cubes.map((props, index) => (
           <Cube key={index} {...props} />
         ))}

--- a/src/app/components/3D/Cube/constants.ts
+++ b/src/app/components/3D/Cube/constants.ts
@@ -4,7 +4,7 @@ import * as THREE from "three";
 
 // 定数を別ファイルに分離
 export const CUBE_CONFIG = {
-  GRID_SIZE: 6, // グリッドの一辺のキューブの数
+  GRID_SIZE: 11, // グリッドの一辺のキューブ数（球の解像度）
   SPACING: 1.2, // キューブ間の間隔
   SCATTER_COUNT: 150, // 散乱させるキューブの数
   SCATTER_RANGE: {

--- a/src/app/components/3D/Cube/generateCubes.tsx
+++ b/src/app/components/3D/Cube/generateCubes.tsx
@@ -5,46 +5,30 @@ import { CUBE_CONFIG, CubeData } from "./constants";
 
 const generateCubes = (): CubeData[] => {
   const cubes: CubeData[] = [];
-  const missingPositions = generateMissingPositions();
 
-  // メインキューブ生成を最適化
-  generateMainCubes(cubes, missingPositions);
-  // 散らばりキューブ生成を最適化
+  // 球状クラウド（蠢く立方体の塊。うねりは Cube.tsx の useFrame が担う）
+  generateCloudCubes(cubes);
+  // 周辺の散らばりキューブ
   generateScatteredCubes(cubes);
 
   return cubes;
 };
 
-// 関数を分割して最適化
-const generateMissingPositions = (): THREE.Vector3[] => {
-  return Array.from(
-    { length: CUBE_CONFIG.SCATTER_COUNT },
-    () =>
-      new THREE.Vector3(
-        Math.floor(Math.random() * CUBE_CONFIG.GRID_SIZE),
-        Math.floor(Math.random() * CUBE_CONFIG.GRID_SIZE),
-        Math.floor(Math.random() * CUBE_CONFIG.GRID_SIZE)
-      )
-  );
-};
+const generateCloudCubes = (cubes: CubeData[]): void => {
+  const { GRID_SIZE, SPACING } = CUBE_CONFIG;
+  const half = (GRID_SIZE - 1) / 2;
 
-const generateMainCubes = (cubes: CubeData[], missingPositions: THREE.Vector3[]): void => {
-  const halfGrid = CUBE_CONFIG.GRID_SIZE / 2;
-
-  for (let x = 0; x < CUBE_CONFIG.GRID_SIZE; x++) {
-    for (let y = 0; y < CUBE_CONFIG.GRID_SIZE; y++) {
-      for (let z = 0; z < CUBE_CONFIG.GRID_SIZE; z++) {
-        if (!isMissingPosition(x, y, z, missingPositions)) {
-          cubes.push(
-            createCube(
-              new THREE.Vector3(
-                (x - halfGrid + 0.5) * CUBE_CONFIG.SPACING,
-                (y - halfGrid + 0.5) * CUBE_CONFIG.SPACING,
-                (z - halfGrid + 0.5) * CUBE_CONFIG.SPACING
-              )
-            )
-          );
-        }
+  for (let i = 0; i < GRID_SIZE; i++) {
+    for (let j = 0; j < GRID_SIZE; j++) {
+      for (let k = 0; k < GRID_SIZE; k++) {
+        const nx = (i - half) / half;
+        const ny = (j - half) / half;
+        const nz = (k - half) / half;
+        // 球をベースに少しハート型へ寄せる（上が膨らみ下が尖る。係数0.4で控えめに）
+        const a = nx * nx + ny * ny + nz * nz - 1;
+        if (a * a * a - nx * nx * ny * ny * ny * 0.4 > 0) continue;
+        const s = SPACING * 0.78; // 中央クラウドのサイズ（散らばりは変えず中央だけ小さく）
+        cubes.push(createCube(new THREE.Vector3((i - half) * s, (j - half) * s, (k - half) * s)));
       }
     }
   }
@@ -69,15 +53,6 @@ const generateScatteredCubes = (cubes: CubeData[]): void => {
       )
     );
   }
-};
-
-const isMissingPosition = (
-  x: number,
-  y: number,
-  z: number,
-  missingPositions: THREE.Vector3[]
-): boolean => {
-  return missingPositions.some((pos) => pos.x === x && pos.y === y && pos.z === z);
 };
 
 // createCubeの最適化


### PR DESCRIPTION
## Summary

トップページの3Dオブジェクトを、穴あき立方体の塊から「ハート寄りに膨らんだ立方体クラウド」へ刷新。第一印象を無機質な塊から情緒的・有機的な体験へ転換する。

## Changes

- 形状: 穴あき立方体グリッド → 球ベース＋弱いハート項の立方体クラウド（上が膨らみ下が尖る）
- 波紋シェーダー: 中心から外へ広がる色の脈動を追加（うねりと同テンポ time*0.55）
- うねり: ノイズ（波の合成）で中心から外へ脈動・うねる有機的な動き
- 構図: 回転を減速(0.0007→0.0005)、クラウドを0.78倍に縮小、奥(Z-15)へ配置して奥行き付与
- 周辺の散らばりキューブ・ピンクのグラデーションは維持

## Test Plan

- [x] \`npx tsc --noEmit\` 型チェック通過
- [x] \`pnpm lint:fix\` lint クリーン
- [x] \`pnpm build\` ビルド成功
- [x] \`pnpm dev\` ブラウザ目視（形・色・波紋・うねり・速度・サイズ・奥行き）

## Breaking Changes

なし（CubeData インターフェース不変、Scene/page 等の契約は据え置き）