### PR TITLE
docs(claude): CLAUDE.md参照修復・検証コマンド補完

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,9 +22,9 @@ src/lib/              -- ユーティリティ
 ## Rules
 
 - `any`禁止、型明示（型安全性）
-- 新規コンポーネント: 関数宣言
+- 新規コンポーネント: 関数宣言（理由: 既存コードベース統一）
 - スタイル: CSS Modules + Tailwind。既存パターン準拠
-- アニメーション: Motion優先。GSAP=既存一貫性時のみ
+- アニメーション: Motion優先。GSAP=既存一貫性時のみ（理由: ランタイム二重化回避）
 - `src/components/ui/` 変更禁止（shadcn/ui自動生成）
 - 新規UI -> `src/app/components/`配置
 - 既存コードのパターンに従う
@@ -39,6 +39,7 @@ src/lib/              -- ユーティリティ
 dev: `pnpm dev`
 build: `pnpm build`
 lint: `pnpm lint:fix`
+typecheck: `pnpm typecheck`
 pkg: pnpm（packageManager設定。npm/yarn不可）
 
 ## Docs


### PR DESCRIPTION
## 概要
authoring-claude-md skill (Review & Optimize Mode) でCLAUDE.mdを5原則評価し改善を適用。スコア 3.5 → 5.0(想定)。

## このPRの変更 (.claude/CLAUDE.md)
- Rules に理由(WHY)を2件付与: 関数宣言(既存コードベース統一) / Motion優先(ランタイム二重化回避)
- Commands に typecheck (pnpm typecheck) を追加 — 検証手順の補完

## ローカルで併せて実施 (本PR外、.docs/ はgitignore対象)
- 切れていた .docs/conventions.md 参照を git履歴(af59d4d)から22行復元

## 検証
- validate-claude-md.sh: 6 PASS / 1 WARN(anti-anchor advisory) / 0 FAIL、47行