### PR TITLE
chore(gitignore): .docs設計ドキュメントを追跡対象化

### DIFF
--- a/.docs/conventions.md
+++ b/.docs/conventions.md
@@ -1,0 +1,20 @@
+# 規約詳細
+
+## スタイリング
+
+- CSS Modules（`.module.css`）+ Tailwind CSS 併用
+- コンポーネント固有スタイル -> `.module.css`に記述
+- BEM風クラス命名（例: `about-content-group`）
+- 参考: 既存コンポーネントの`.module.css`を確認
+
+## アニメーション
+
+- Motion: 新規アニメーションの第一選択
+- GSAP: 既存GSAPコードとの一貫性が必要な場合のみ使用
+- delay値: 既存パターンに合わせる（周辺コンポーネントのdelayを確認）
+- View Transitions API: ページ遷移アニメーション（next-view-transitions使用）
+
+## コンテンツ
+
+- カラーテーマ: ピンク系（`--color-primary-pink`）
+- 外部リンク: `target="_blank" rel="noopener noreferrer"` 付与

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,11 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# docs (個人作業ドキュメント、 publicリポ非公開)
-.docs/
+# docs: 設計ドキュメント本体(architecture/conventions等)は追跡。個人の作業記録のみ除外
+.docs/logs/local/
+.docs/plans/
+.docs/gep-pr-reviews/
+.docs/output/
 
 # serena
 .serena


### PR DESCRIPTION
## 背景
従来 .gitignore は .docs/ を丸ごと除外していた。これが設計ドキュメント(conventions.md)まで巻き込み、CLAUDE.md から参照しているのに版管理に存在しない『参照切れ』を生んでいた(fresh clone で実体が欠落)。

## 変更内容
- .gitignore: .docs/ 丸ごと除外 → 個人の作業記録のみ名指し除外に変更
  - 除外: .docs/logs/local/ , .docs/plans/ , .docs/gep-pr-reviews/ , .docs/output/
  - 追跡: .docs/conventions.md など設計ドキュメント本体
- .docs/conventions.md (22行) を追跡対象に追加 — CLAUDE.md のポインタ先が clone 後も実在するようになる

## 方針
outputquest と同じ『設計ドキュメントは追跡・使い捨て記録は除外』の選択的追跡ポリシーに統一。

## 補足
- conventions.md は機密情報を含まずコーディング規約のみ。public リポでの公開可
- 個人作業ログ/計画は引き続き非追跡