### PR TITLE
fix: アカウント改名に追従 (kaijutale → dendedev / kaiju → Dende)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ https://github.com/user-attachments/assets/4365ea0e-4dbd-449f-8a30-6e5c7962005a
 
 <h2 id="development-configuration-diagram">開発構成図</h2>
 
-[開発構成図](https://kaijutale.github.io/portfolio-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
+[開発構成図](https://dendedev.github.io/portfolio-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
 
 <h2 id="directory-design">ディレクトリ構造</h2>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://aoyama.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kaijutale/portfolio-site"
+    "url": "https://github.com/dendedev/portfolio-site"
   },
   "packageManager": "pnpm@10.11.1",
   "scripts": {

--- a/src/app/components/layouts/Header/Header.tsx
+++ b/src/app/components/layouts/Header/Header.tsx
@@ -52,7 +52,7 @@ export default function Header() {
             onClick={() => isOpen && toggleMenu()}
           >
             <span className={`${styles["text-gradient"]} ${styles["rotate-text01"]}`}>kaishu</span>
-            <span className={`${styles["text-gradient"]} ${styles["rotate-text02"]}`}>kaiju</span>
+            <span className={`${styles["text-gradient"]} ${styles["rotate-text02"]}`}>dende</span>
           </Link>
         </div>
         <div className={styles["header__items"]}>

--- a/src/app/features/about/components/HobbySection/HobbySection.tsx
+++ b/src/app/features/about/components/HobbySection/HobbySection.tsx
@@ -28,7 +28,7 @@ const HobbySection = () => {
               </em>
               と考え、
               <a
-                href="https://github.com/kaijutale/outputquest"
+                href="https://github.com/dendedev/outputquest"
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles["about-product-link"]}
@@ -39,8 +39,8 @@ const HobbySection = () => {
             </p>
             <p>
               <span className={`font-bold ${styles["light-effect"]}`}>現在の注力</span>
-              ：AI-Driven Development / Agentic Engineering / Agent Harness / Multi-Agent Orchestration / Claude Code /
-              Next.js / React / UI / UX / Interaction
+              ：AI-Driven Development / Agentic Engineering / Agent Harness / Multi-Agent
+              Orchestration / Claude Code / Next.js / React / UI / UX / Interaction
             </p>
           </HobbyItem>
 

--- a/src/app/features/about/components/ProfileSection/ProfileSection.tsx
+++ b/src/app/features/about/components/ProfileSection/ProfileSection.tsx
@@ -37,7 +37,7 @@ const ProfileSection = () => {
             <div className={styles["about-profile-info"]}>
               <ProfileItem label="Birthday" value="1999 / 07 / 10" />
               <ProfileItem label="Name" value="Kaishu Aoyama" />
-              <ProfileItem label="Nickname" value="kaiju - かいじゅう" />
+              <ProfileItem label="Nickname" value="Dende" />
             </div>
           </dl>
         </div>
@@ -49,11 +49,11 @@ const ProfileSection = () => {
         <div className={styles["about-sns-content"]}>
           <ul className={styles["about-sns-list"]}>
             <SnsItem
-              href="https://github.com/kaijutale"
+              href="https://github.com/dendedev"
               logo="/images/about/sns/github-logo.svg"
               name="GitHub"
             />
-            <SnsItem href="https://x.com/kaijutale" logo="/images/about/sns/x-logo.svg" name="X" />
+            <SnsItem href="https://x.com/dendedev" logo="/images/about/sns/x-logo.svg" name="X" />
             <SnsItem
               href="https://zenn.dev/camoneart"
               logo="/images/about/sns/zenn-logo.svg"

--- a/src/app/features/works/data/works.ts
+++ b/src/app/features/works/data/works.ts
@@ -171,12 +171,12 @@ export const worksData: WorksData[] = [
     detail12:
       "　`.maestro.json`でプロジェクトごとに挙動をカスタマイズ可能です。worktreeの保存先、自動セットアップコマンド、同期ファイル、ライフサイクルフック、tmux/GitHub/Claude連携などの柔軟な設定に加え、`postCreate`フックで環境構築の自動化が可能です。",
     detail13:
-      "　必要なのはNode.js 20以上のみです。`brew install kaijutale/tap/maestro`または`npm install -g @camoneart/maestro`または`pnpm add -g @camoneart/maestro`ですぐにインストールできます。",
+      "　必要なのはNode.js 20以上のみです。`brew install dendedev/tap/maestro`または`npm install -g @camoneart/maestro`または`pnpm add -g @camoneart/maestro`ですぐにインストールできます。",
     accessDescription: "",
     labels: [{ no: "Card No.", value: "003/003" }],
     skillsList:
       "TypeScript, commander, simple-git, execa, inquirer, chalk, ora, zod, cli-progress, chokidar, conf, p-limit, open, modelcontextprotocol/sdk, tsup, vitest",
-    siteUrl: "https://github.com/kaijutale/maestro",
+    siteUrl: "https://github.com/dendedev/maestro",
     role: "Design, Coding",
     viewTransitionName: "view-transition-title-work-3",
     viewTransitionImage: "view-transition-img-work-3",


### PR DESCRIPTION
## 概要

GitHub / X アカウント改名 `kaijutale -> dendedev` に追従し、リポジトリ内にハードコードされた URL を更新する。併せてサイト表示上のニックネーム `kaiju` を `Dende` に変更する。

`github.com/kaijutale` (ユーザープロフィール) は既に **404** になっており、About ページの GitHub リンクが切れている状態のため修正が必要。

## 変更 (1 commit / 10 箇所 / 6 ファイル)

`fix: アカウント改名に追従 (kaijutale → dendedev / kaiju → Dende)`

### A. `kaijutale -> dendedev` (7 箇所)

| ファイル | 内容 |
|---|---|
| `README.md` | 開発構成図の GitHub Pages URL |
| `package.json` | `repository.url` |
| `HobbySection.tsx` | outputquest リポジトリリンク |
| `ProfileSection.tsx` | SNS: GitHub プロフィールリンク |
| `ProfileSection.tsx` | SNS: X アカウントリンク |
| `works.ts` | `brew install dendedev/tap/maestro` (Homebrew tap 部分のみ) |
| `works.ts` | maestro の `siteUrl` |

### B. `kaiju -> Dende` (2 箇所)

| ファイル | 内容 |
|---|---|
| `Header.tsx` | ヘッダーロゴ `kaiju` -> `dende` (ロゴは全小文字が既存パターンのため小文字) |
| `ProfileSection.tsx` | Nickname `kaiju - かいじゅう` -> `Dende` (カナを削除、大文字始まり) |

## 変更しないもの (意図的、対象外)

- **`.docs/` 配下 61 箇所の `kaijutale`**: `2026-06-02-rename-camoneart-to-kaijutale*.md` 等の過去作業の履歴記録。当時アカウントが `kaijutale` だった事実の記録であり、書き換えは記録の改竄にあたる。gitignore 済みで未追跡。
- **npm 名前空間 `@camoneart/maestro`** (`works.ts` の `npm install` / `pnpm add`): npm レジストリ側の別管理で GitHub 改名と独立。前回改名時から継続して据え置き。
  - 補足: 同じ行で `brew install dendedev/tap/maestro` だけ更新したのは、Homebrew tap が `github.com/dendedev/homebrew-tap` に解決され GitHub 改名に追従するため。同一行で npm scope (`@camoneart`) と tap (`dendedev`) の表記が割れて見えるが仕様であって誤りではない。
- **Zenn** (`zenn.dev/camoneart`): Zenn の仕様上ユーザー名変更が不可のため据え置き。
- **`kaishu` / `Kaishu Aoyama`**: 本名であり今回の改名スコープ外。

## リンク疎通確認 (gh api, read-only)

- `dendedev`: 実在 (id: 106678583) / `kaijutale`: **404** (= 改名完了の裏付け)
- `github.com/dendedev/{portfolio-site, outputquest, maestro, homebrew-tap}`: 全て実在
- `dendedev.github.io/portfolio-development-configuration-diagram/`: GitHub Pages `status=built` で公開済み (README のリンク先と一致)
- `x.com/dendedev`: アカウント側で変更済み (X は API で裏取り不可のため本人申告による)

## 検証

- `tsc --noEmit`: **PASS** (exit 0、型エラーなし)
- `next dev` 起動: **PASS** (Ready in 413ms / Next.js 16.2.11 Turbopack)
- 残存 `kaiju` (git 追跡下・大小無視): **0 件**
- `@camoneart/maestro` の無傷確認: 2 箇所残存 (= 意図通り)
- build 完走 / lint: 未実施 -- `RESEND_API_KEY` 未設定で `/api/send` が落ちる env 要因、および `next lint` が Next.js 16 で削除済み + `eslint.config` 不在。いずれも既存環境の別課題で本変更と無関係。

## 目視確認ポイント

- `/about` -- Nickname が `Dende`、SNS の GitHub / X リンクの遷移先
- `/works/3` -- maestro のインストール手順とサイトリンク
- 全ページ共通 -- ヘッダーロゴ `kaishu` / `dende`

## 備考

- `HobbySection.tsx` の「現在の注力」行に prettier (PostToolUse hook) の再折り返し差分が 1 箇所混入。文言は不変で改名とは無関係。前回改名時にも発生した既知の副作用。
- ローカルの `git remote` は `git@github.com:dendedev/portfolio-site.git` へ張り替え済み (リポジトリ転送は生きているため push 自体は改名前 URL でも通るが、実体を指すよう更新)。
