### PR TITLE
fix: README のバージョン記載ズレを是正し @types/three を three に追従

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ https://github.com/user-attachments/assets/4365ea0e-4dbd-449f-8a30-6e5c7962005a
 
 ### フロント
 
-- [Next.js](https://nextjs.org/)：v16.2.4
-- [React](https://ja.react.dev/)：v19.2.5
+- [Next.js](https://nextjs.org/)：v16.2.12
+- [React](https://ja.react.dev/)：v19.2.8
 - [TypeScript](https://www.typescriptlang.org/)：v6.0.3
 
 ### スタイル・UI
 
-- [Tailwind CSS](https://tailwindcss.com/)：v4.1.18
+- [Tailwind CSS](https://tailwindcss.com/)：v4.2.4
 - [shadcn/ui](https://ui.shadcn.com/)
 
 ### アニメーション
@@ -141,8 +141,8 @@ https://github.com/user-attachments/assets/4365ea0e-4dbd-449f-8a30-6e5c7962005a
 
 ### 3Dコンテンツ
 
-- [Three.js](https://threejs.org/)：v0.184.0
-- [React Three Fiber](https://r3f.docs.pmnd.rs/getting-started/introduction)：v9.6.0
+- [Three.js](https://threejs.org/)：v0.185.1
+- [React Three Fiber](https://r3f.docs.pmnd.rs/getting-started/introduction)：v9.7.0
 - [Drei](https://drei.docs.pmnd.rs/getting-started/introduction)：v10.7.7
 - [React Spring](https://www.react-spring.dev/)：v10.0.3
 
@@ -152,8 +152,8 @@ https://github.com/user-attachments/assets/4365ea0e-4dbd-449f-8a30-6e5c7962005a
 
 ### フォーム・スキーマバリデーション
 
-- [React Hook Form](https://react-hook-form.com/)：v7.71.1（フォーム）
-- [Zod](https://zod.dev/)：v4.3.5（スキーマバリデーション）
+- [React Hook Form](https://react-hook-form.com/)：v7.74.0（フォーム）
+- [Zod](https://zod.dev/)：v4.3.6（スキーマバリデーション）
 
 ### メール送信サービス
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-spring/web": "10.0.3",
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.7.0",
-    "@types/three": "0.184.0",
+    "@types/three": "0.185.3",
     "class-variance-authority": "0.7.1",
     "client-only": "0.0.1",
     "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,13 +54,13 @@ importers:
         version: 10.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-three/drei':
         specifier: 10.7.7
-        version: 10.7.7(@react-three/fiber@9.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1))(@types/react@19.2.18)(@types/three@0.184.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)
+        version: 10.7.7(@react-three/fiber@9.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1))(@types/react@19.2.18)(@types/three@0.185.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)
       '@react-three/fiber':
         specifier: 9.7.0
         version: 9.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)
       '@types/three':
-        specifier: 0.184.0
-        version: 0.184.0
+        specifier: 0.185.3
+        version: 0.185.3
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -1199,8 +1199,8 @@ packages:
   '@types/stylis@4.2.7':
     resolution: {integrity: sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==}
 
-  '@types/three@0.184.0':
-    resolution: {integrity: sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==}
+  '@types/three@0.185.3':
+    resolution: {integrity: sha512-8TqTn1+fjPWuJ4mR6Igtg56DCf9b5EeAlwhb5xaa6WlBrsg7SvG0NQbyctGRkHCKwg0uftfCspOEsTXelgktMA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -4277,7 +4277,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@react-three/drei@10.7.7(@react-three/fiber@9.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1))(@types/react@19.2.18)(@types/three@0.184.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)':
+  '@react-three/drei@10.7.7(@react-three/fiber@9.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1))(@types/react@19.2.18)(@types/three@0.185.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@mediapipe/tasks-vision': 0.10.17
@@ -4289,10 +4289,10 @@ snapshots:
       detect-gpu: 5.0.70
       glsl-noise: 0.0.0
       hls.js: 1.6.15
-      maath: 0.10.8(@types/three@0.184.0)(three@0.185.1)
+      maath: 0.10.8(@types/three@0.185.3)(three@0.185.1)
       meshline: 3.3.1(three@0.185.1)
       react: 19.2.8
-      stats-gl: 2.4.2(@types/three@0.184.0)(three@0.185.1)
+      stats-gl: 2.4.2(@types/three@0.185.3)(three@0.185.1)
       stats.js: 0.17.0
       suspend-react: 0.1.3(react@19.2.8)
       three: 0.185.1
@@ -4472,7 +4472,7 @@ snapshots:
 
   '@types/stylis@4.2.7': {}
 
-  '@types/three@0.184.0':
+  '@types/three@0.185.3':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
       '@tweenjs/tween.js': 23.1.3
@@ -5928,9 +5928,9 @@ snapshots:
     dependencies:
       react: 19.2.8
 
-  maath@0.10.8(@types/three@0.184.0)(three@0.185.1):
+  maath@0.10.8(@types/three@0.185.3)(three@0.185.1):
     dependencies:
-      '@types/three': 0.184.0
+      '@types/three': 0.185.3
       three: 0.185.1
 
   magic-string@0.30.21:
@@ -6695,9 +6695,9 @@ snapshots:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
-  stats-gl@2.4.2(@types/three@0.184.0)(three@0.185.1):
+  stats-gl@2.4.2(@types/three@0.185.3)(three@0.185.1):
     dependencies:
-      '@types/three': 0.184.0
+      '@types/three': 0.185.3
       three: 0.185.1
 
   stats.js@0.17.0: {}


### PR DESCRIPTION
## 概要

README の「使用技術」に手書きされたバージョンが実際の依存とズレていたのを是正し、併せて `@types/three` を `three` に追従させる。

**目的は「README と package.json のバージョンを常に一致させる」こと。** 本 PR はその基準を作る第 1 段で、自動同期の実装 (第 2 段) は別 PR で行う。

## 変更 (2 commit)

### 1. `docs(readme)`: バージョン記載を実測値へ同期 (7 箇所)

| ライブラリ | before | after |
|---|---|---|
| Next.js | v16.2.4 | **v16.2.12** |
| React | v19.2.5 | **v19.2.8** |
| Tailwind CSS | v4.1.18 | **v4.2.4** |
| Three.js | v0.184.0 | **v0.185.1** |
| React Three Fiber | v9.6.0 | **v9.7.0** |
| React Hook Form | v7.71.1 | **v7.74.0** |
| Zod | v4.3.5 | **v4.3.6** |

一致していた 8 項目 (TypeScript / GSAP / Motion / next-view-transitions / Drei / React Spring / Howler.js / Resend) は変更なし。

README への仕掛け (同期範囲を示すマーカー等) は入れていない。第 2 段の同期スクリプトは「README の表示名 -> package.json のキー」の対応表を持つ設計で、その対応表自体が書き換え対象の境界として機能するため、文書側にマーカーを置く必要がない (プロトタイプで検証済み。詳細は下記)。

### 2. `fix(deps)`: `@types/three` を 0.185.3 へ

`three` は #117 で 0.184.0 -> 0.185.1 に上がったが、`@types/three` は 0.184.0 に取り残されていた。型定義とランタイムのバージョンがズレた状態。

`three` は自前の型定義を同梱していない (`package.json` に `types` フィールドなし) ため `@types/three` は必須で、本コードベースも 6 ファイル以上で `import * as THREE from "three"` している。よって削除ではなく追従が正しい。

## ズレが発生した理由 (再発防止の前提)

README のバージョンは **手書きの重複データ**であり、Dependabot が依存を更新しても自動では追従しない。CI も検知しない。実際、React Hook Form と Zod のズレは今回の一斉更新とは無関係で、**以前から存在していた**。

**ローカルの git hook では解決できない。** Dependabot の PR 作成・マージは GitHub 上で完結するため、ローカルで発火する仕組みは 1 件も捕捉できない。

## 検証 (すべてローカル実測)

| 項目 | 結果 |
|---|---|
| README 15 項目 vs package.json の突合 | **ズレ 0 件** (スクリプトで機械照合) |
| `pnpm typecheck` | **exit 0** (error TS 0 件) |
| `pnpm lint` | **exit 0** |
| `pnpm audit --audit-level=high` | **exit 0** |
| `pnpm build` | **exit 0** (`Compiled successfully` / 静的ページ 37/37 生成) |

`@types/three` の更新は 3D コンポーネント (Cube / NetworkBackground) の型解決に直接影響するため、`typecheck` に加えて `build` まで実行した。

## 次段の予定 (本 PR のスコープ外)

`push: main` で発火する GitHub Actions ワークフローを追加し、`package.json` から README のバージョン記載を再生成して差分があれば commit する。Dependabot のマージも含めて捕捉できる唯一の位置のため。

同期の仕組みはプロトタイプで先に検証済み:

- 対応表 (README 表示名 -> package.json キー) を持ち、`- [表示名](URL)：vX.Y.Z` 形式の行のみを対象にする
- 現行 README に対して実行 -> 15 項目を捕捉し差分ゼロ (同期済みの状態を正しく判定)
- README には同形式の行が 17 行あるが、対応表に無い `node` / `pnpm` の 2 行は**自動的に対象外**になる (`node` は package.json に記載なし、`pnpm` は `packageManager` フィールド)
- 意図的に 3 箇所を旧版へ戻し、さらに紛らわしい行を 1 行混ぜたコピーで実行 -> 4 箇所すべて検出・是正

対応表が書き換え対象の境界を定義するため、文書側のマーカーは不要と判断した。「どこを書き換えるか」の定義がコード 1 箇所に集約され、README の構成変更時に 2 箇所を同期させる必要がなくなる。

CI で drift を検出して fail させる方式は **採らない** — Dependabot の PR が毎回赤くなり、「赤い PR が常態化して本物の失敗が埋もれる」状態を再生産するため (今回 #107 の実失敗が 7 本の時限式失敗に埋もれていたのが実例)。
