### PR TITLE
fix: アカウント改名に追従 (dendedev → mirinodev / Dende → Mirino)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ https://github.com/user-attachments/assets/4365ea0e-4dbd-449f-8a30-6e5c7962005a
 
 <h2 id="development-configuration-diagram">開発構成図</h2>
 
-[開発構成図](https://dendedev.github.io/portfolio-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
+[開発構成図](https://mirinodev.github.io/portfolio-development-configuration-diagram/)はHTMLインフォグラフィックで表現しました。
 
 <h2 id="directory-design">ディレクトリ構造</h2>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://aoyama.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dendedev/portfolio-site"
+    "url": "https://github.com/mirinodev/portfolio-site"
   },
   "packageManager": "pnpm@10.11.1",
   "scripts": {

--- a/src/app/components/layouts/Header/Header.tsx
+++ b/src/app/components/layouts/Header/Header.tsx
@@ -52,7 +52,7 @@ export default function Header() {
             onClick={() => isOpen && toggleMenu()}
           >
             <span className={`${styles["text-gradient"]} ${styles["rotate-text01"]}`}>kaishu</span>
-            <span className={`${styles["text-gradient"]} ${styles["rotate-text02"]}`}>dende</span>
+            <span className={`${styles["text-gradient"]} ${styles["rotate-text02"]}`}>mirino</span>
           </Link>
         </div>
         <div className={styles["header__items"]}>

--- a/src/app/features/about/components/HobbySection/HobbySection.tsx
+++ b/src/app/features/about/components/HobbySection/HobbySection.tsx
@@ -28,7 +28,7 @@ const HobbySection = () => {
               </em>
               と考え、
               <a
-                href="https://github.com/dendedev/outputquest"
+                href="https://github.com/mirinodev/outputquest"
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles["about-product-link"]}

--- a/src/app/features/about/components/ProfileSection/ProfileSection.tsx
+++ b/src/app/features/about/components/ProfileSection/ProfileSection.tsx
@@ -37,7 +37,7 @@ const ProfileSection = () => {
             <div className={styles["about-profile-info"]}>
               <ProfileItem label="Birthday" value="1999 / 07 / 10" />
               <ProfileItem label="Name" value="Kaishu Aoyama" />
-              <ProfileItem label="Nickname" value="Dende" />
+              <ProfileItem label="Nickname" value="Mirino" />
             </div>
           </dl>
         </div>
@@ -49,11 +49,11 @@ const ProfileSection = () => {
         <div className={styles["about-sns-content"]}>
           <ul className={styles["about-sns-list"]}>
             <SnsItem
-              href="https://github.com/dendedev"
+              href="https://github.com/mirinodev"
               logo="/images/about/sns/github-logo.svg"
               name="GitHub"
             />
-            <SnsItem href="https://x.com/dendedev" logo="/images/about/sns/x-logo.svg" name="X" />
+            <SnsItem href="https://x.com/mirinodev" logo="/images/about/sns/x-logo.svg" name="X" />
             <SnsItem
               href="https://zenn.dev/camoneart"
               logo="/images/about/sns/zenn-logo.svg"

--- a/src/app/features/works/data/works.ts
+++ b/src/app/features/works/data/works.ts
@@ -171,12 +171,12 @@ export const worksData: WorksData[] = [
     detail12:
       "　`.maestro.json`でプロジェクトごとに挙動をカスタマイズ可能です。worktreeの保存先、自動セットアップコマンド、同期ファイル、ライフサイクルフック、tmux/GitHub/Claude連携などの柔軟な設定に加え、`postCreate`フックで環境構築の自動化が可能です。",
     detail13:
-      "　必要なのはNode.js 20以上のみです。`brew install dendedev/tap/maestro`または`npm install -g @camoneart/maestro`または`pnpm add -g @camoneart/maestro`ですぐにインストールできます。",
+      "　必要なのはNode.js 20以上のみです。`brew install mirinodev/tap/maestro`または`npm install -g @camoneart/maestro`または`pnpm add -g @camoneart/maestro`ですぐにインストールできます。",
     accessDescription: "",
     labels: [{ no: "Card No.", value: "003/003" }],
     skillsList:
       "TypeScript, commander, simple-git, execa, inquirer, chalk, ora, zod, cli-progress, chokidar, conf, p-limit, open, modelcontextprotocol/sdk, tsup, vitest",
-    siteUrl: "https://github.com/dendedev/maestro",
+    siteUrl: "https://github.com/mirinodev/maestro",
     role: "Design, Coding",
     viewTransitionName: "view-transition-title-work-3",
     viewTransitionImage: "view-transition-img-work-3",


### PR DESCRIPTION
## 概要

GitHub / X アカウント改名 `dendedev -> mirinodev` に追従し、リポジトリ内にハードコードされた URL を更新する。併せてサイト表示上のニックネーム `Dende` を `Mirino` に変更する。

## 変更内容 (6 ファイル / 9 箇所)

### A. `dendedev -> mirinodev` (7 箇所)

| ファイル | 箇所 |
| --- | --- |
| `README.md` | 開発構成図の GitHub Pages URL |
| `package.json` | `repository.url` |
| `HobbySection.tsx` | OUTPUT QUEST (outputquest) リンク |
| `ProfileSection.tsx` | SNS の GitHub リンク |
| `ProfileSection.tsx` | SNS の X リンク |
| `works.ts` | `brew install mirinodev/tap/maestro` (Homebrew tap 部分のみ) |
| `works.ts` | maestro の `siteUrl` |

### B. `Dende -> Mirino` (2 箇所)

| ファイル | 箇所 |
| --- | --- |
| `Header.tsx` | ヘッダーロゴ `dende` -> `mirino` (ロゴは全小文字が既存パターンのため小文字) |
| `ProfileSection.tsx` | Nickname `Dende` -> `Mirino` (`Kaishu Aoyama` と並ぶため大文字始まり) |

## 意図的に変更しなかったもの

- **npm scope `@camoneart/maestro`** (`works.ts` の Homebrew tap と同じ行) — npm の scope であり GitHub 改名とは無関係。同一行で tap (`mirinodev`) と npm scope (`@camoneart`) の表記が割れて見えるが仕様であって誤りではない。
- **Zenn リンク `zenn.dev/camoneart`** — 別サービスのアカウントで今回の改名対象外。
- **gitignored な作業記録 42 箇所** (`.docs/logs/local/` 2 ファイル / `.docs/plans/archived/` 1 ファイル / `.claude/handoff-state.md`) — 「過去に何が起きたか」の記録であり、書き換えると記録の意味が失われるため据え置き。

## 着手前の裏取り (本 PR のセッションで実測)

改名前に URL を変えると 404 になるため、前回改名 (`kaijutale -> dendedev`) と同じゲートを踏襲した。

| 検査 | コマンド | 結果 |
| --- | --- | --- |
| 新アカウント実在 | `gh api users/mirinodev` | OK `id=106678583` `login=mirinodev` |
| 旧アカウント消滅 | `gh api users/dendedev` | **404** (= 改名完了の裏付け) |
| リポジトリ 4 件 | `gh api repos/mirinodev/{portfolio-site,outputquest,maestro,homebrew-tap}` | 全て実在 |
| GitHub Pages | `gh api repos/mirinodev/portfolio-development-configuration-diagram/pages` | `status=built` / `html_url` が README のリンク先と一致 |
| remote 疎通 | `git ls-remote origin HEAD` | OK |

`id=106678583` は、前回改名 PR の body に記録されていた `dendedev` の id と一致する。別アカウント新設ではなく同一アカウントの改名であることの裏付け。

**`x.com/mirinodev` は X 側の API で裏取りできないため、本人申告による。**

## 検証

- `pnpm typecheck` — エラーなし
- `pnpm lint` — エラーなし
- `git grep -niI dende` (追跡対象ファイル) — **0 件**
- ローカル dev サーバーでブラウザ実機確認 (Chrome DevTools MCP)
  - `/about` — Nickname `Mirino` / SNS の GitHub・X リンク先 / OUTPUT QUEST リンク先
  - `/works/3` — maestro の URL / `brew install mirinodev/tap/maestro`
  - console の error 0 件 (warn 5 件はいずれも改名前から存在する既存のもの)

**未実施**: `pnpm build` (typecheck / lint のみ実行)

## 確認観点

- `/about` — Nickname が `Mirino`、SNS の GitHub / X リンクの遷移先
- `/works/3` — maestro の URL と Homebrew のインストールコマンド
- 全ページ共通 — ヘッダーロゴ。**768px 以上の幅でロゴに hover した時だけ** `kaishu` -> `mirino` へ 3D 回転する演出のため、hover しないと `mirino` は見えない

## 補足

ローカルの `git remote` は `git@github.com:mirinodev/portfolio-site.git` へ張り替え済み (リポジトリ転送は生きているため push 自体は改名前 URL でも通るが、実体を指すよう更新)。
